### PR TITLE
Do not filter NaNs when preprocessing test data.

### DIFF
--- a/src/bayesnf/spatiotemporal.py
+++ b/src/bayesnf/spatiotemporal.py
@@ -175,7 +175,7 @@ class SpatiotemporalDataHandler:
 
   def get_test(self, table: pd.DataFrame) -> np.ndarray:
     """Fetch testing data. Call this after `get_train`."""
-    table = self.copy_and_filter_table(table)
+    table = table.copy()
     table, _ = _convert_datetime_col(
         table, self._time_column, self.timetype, self.freq, self.time_min_)
 


### PR DESCRIPTION
When running `.predict`, it should not matter if the target column is `NaN`, and right now this causes surprising behavior. 