### PR TITLE
Remove polyfill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,6 @@ watch:
 extra_javascript:
     # https://squidfunk.github.io/mkdocs-material/reference/mathjax/
     - _static/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION

It looks like https://caniuse.com/?search=es6#google_vignette ~97% of users have browsers that support es6 features, and it isn't clear to me which es6 features we are using, so this seems safe. 