### PR TITLE
Update predict docstring to new *points* in the field, not just times

### DIFF
--- a/src/bayesnf/spatiotemporal.py
+++ b/src/bayesnf/spatiotemporal.py
@@ -370,7 +370,7 @@ class BayesianNeuralFieldEstimator:
     }
 
   def predict(self, table, quantiles=(0.5,), approximate_quantiles=False):
-    """Make predictions of the target column at new times.
+    """Make predictions of the target column at new points in the field.
 
     Args:
       table (pandas.DataFrame):


### PR DESCRIPTION
Points in the spatiotemporal fields refers to both time and space.

Related #55